### PR TITLE
IPNS speed up

### DIFF
--- a/sample_config/base_config.ini
+++ b/sample_config/base_config.ini
@@ -49,7 +49,7 @@ p2p-listen-endpoint = 0.0.0.0:9876
 p2p-server-address = 0.0.0.0:9876
 
 # True to require exact match of peer network version.
-network-version-match = 0
+network-version-match = 1
 
 # Enable block production, even if the chain is stale.
 #enable-stale-production = true

--- a/sample_config/run_ipfs.sh
+++ b/sample_config/run_ipfs.sh
@@ -12,4 +12,4 @@ fi
 #./ipfs config Addresses.Gateway /ip4/127.0.0.1/tcp/8081  # instead of 8080
 #./ipfs config Addresses.API /ip4/127.0.0.1/tcp/5002      # instead of 5001, you'll need to use --ipfs-api-address /ip4/
 
-./ipfs daemon --init
+./ipfs daemon --enable-namesys-pubsub --init


### PR DESCRIPTION
from https://ipfs.io/blog/34-go-ipfs-0.4.14

"...With the new pubsub IPNS resolver and publisher, you can subscribe to updates of an IPNS entry, and the owner can publish out changes in real time. With this, IPNS can become nearly instantaneous. To make use of this, simply start your go-ipfs daemon with the --enable-namesys-pubsub option, and all IPNS resolution and publishing will use pubsub. ..."