### PR TITLE
add max-irreversible-block-age to default config

### DIFF
--- a/sample_config/base_config.ini
+++ b/sample_config/base_config.ini
@@ -1,6 +1,9 @@
 # Limits the maximum time (in milliseconds) processing a single get_transactions call.
 get-transactions-time-limit = 3
 
+# Limits the maximum age (in seconds) of the DPOS Irreversible Block for a chain this node will produce blocks on
+max-irreversible-block-age=5000000
+
 # the location of the block log (absolute path or relative to application data dir)
 blocks-dir = "blocks"
 


### PR DESCRIPTION
it has created few issues when ABPs won't produce after missing some blocks