### PR TITLE
fixed. compile error

### DIFF
--- a/bios/bios.go
+++ b/bios/bios.go
@@ -543,7 +543,7 @@ type ValidationError struct {
 	RawAction         []byte
 	Index             int
 	ActionHexData     string
-	PackedTransaction eos.PackedTransaction
+	PackedTransaction *eos.PackedTransaction
 }
 
 func (e ValidationError) Error() string {


### PR DESCRIPTION
src/github.com/eoscanada/eos-bios/bios/bios.go:669:24: cannot use receipt.Transaction.Packed (type *eos.PackedTransaction) as type eos.PackedTransaction in field value
src/github.com/eoscanada/eos-bios/bios/bios.go:684:24: cannot use receipt.Transaction.Packed (type *eos.PackedTransaction) as type eos.PackedTransaction in field value