### PR TITLE
Improved how we kill the previous exiting docker container

### DIFF
--- a/bootseqs/launch-clone/boot.sh
+++ b/bootseqs/launch-clone/boot.sh
@@ -8,8 +8,11 @@
 #
 # This process must not BLOCK.
 
-docker kill -s TERM nodeos-bios || true
-docker rm nodeos-bios || true
+# Just in case, maybe delete the previous temp that might have not been deleted before
+docker rm nodeos-bios-temp &> /dev/null || true
+
+docker rename nodeos-bios nodeos-bios-temp || true
+docker kill -s TERM nodeos-bios-temp || true
 
 echo "Copying base config"
 cp base_config.ini config.ini
@@ -43,3 +46,6 @@ echo "Waiting 2 secs for nodeos to launch through Docker"
 sleep 2
 
 echo "See output.log for details logs"
+
+# We put this here to let time for the actual kill to happen
+docker rm nodeos-bios-temp || true

--- a/bootseqs/release-v1.1/boot.sh
+++ b/bootseqs/release-v1.1/boot.sh
@@ -10,8 +10,11 @@
 #
 # This process must not BLOCK.
 
-docker kill -s TERM nodeos-bios || true
-docker rm nodeos-bios || true
+# Just in case, maybe delete the previous temp that might have not been deleted before
+docker rm nodeos-bios-temp &> /dev/null || true
+
+docker rename nodeos-bios nodeos-bios-temp || true
+docker kill -s TERM nodeos-bios-temp || true
 
 echo "Copying base config"
 cp base_config.ini config.ini
@@ -24,12 +27,12 @@ echo "enable-stale-production = true" >> config.ini
 echo "signature-provider = $2=KEY:$3" >> config.ini
 
 echo "Removing old nodeos data (you might be asked for your sudo password)..."
-sudo rm -rf /tmp/nodeos-data
+rm -rf /tmp/nodeos-data
 
 echo "Running 'nodeos' through Docker."
 docker run -ti --rm --detach --name nodeos-bios \
        -v `pwd`:/etc/nodeos -v /tmp/nodeos-data:/data \
-       -p 8888:8888 -p 9876:9876 \
+       -p 127.0.0.1:8888:8888 -p 127.0.0.1:9876:9876 \
        gcr.io/eoscanada-public/eosio-nodeos-prod:v1.1.0-16.04 \
        /opt/eosio/bin/nodeos --data-dir=/data \
                              --config-dir=/etc/nodeos \
@@ -45,3 +48,6 @@ echo "Waiting 2 secs for nodeos to launch through Docker"
 sleep 2
 
 echo "See output.log for details logs"
+
+# We put this here to let time for the actual kill to happen
+docker rm nodeos-bios-temp || true


### PR DESCRIPTION
The docker container is renamed before being kill. This let us run a new one with the correct name and destroy the previous one at the very end of the boot sequence.